### PR TITLE
feat(front): fixes canchas/reservas + botones + auth basic

### DIFF
--- a/lib/config/env.dart
+++ b/lib/config/env.dart
@@ -1,5 +1,8 @@
-/// Variables de configuración de mi app Flutter.
+// lib/env.dart
 class Env {
-  /// URL base de mi backend Spring Boot (ajústala si usas otro puerto/host).
-  static const String baseUrl = 'http://localhost:8080';
+  /// URL base de tu backend (sin / al final)
+  static const String apiBase = 'http://75.101.224.153:8080';
 }
+
+
+

--- a/lib/core/api_client.dart
+++ b/lib/core/api_client.dart
@@ -1,0 +1,84 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+import '../config/env.dart';
+import 'session.dart';
+
+class ApiClient {
+  ApiClient();
+
+  final http.Client _http = http.Client();
+  final String _base = Env.apiBase; // p.ej: http://75.101.224.153:8080
+
+  Uri _uri(String path, [Map<String, String>? query]) {
+    final base = Uri.parse(_base);
+
+    String joinPath(String a, String b) {
+      if (a.endsWith('/')) a = a.substring(0, a.length - 1);
+      if (b.startsWith('/')) b = b.substring(1);
+      return '$a/$b';
+    }
+
+    return Uri(
+      scheme: base.scheme,
+      host: base.host,
+      port: base.port,
+      path: joinPath(base.path.isEmpty ? '/' : base.path, path),
+      queryParameters: (query == null || query.isEmpty) ? null : query,
+    );
+  }
+
+  Map<String, String> _headers({bool withAuth = true, Map<String, String>? extra}) => {
+        'Content-Type': 'application/json',
+        if (withAuth && Session.authHeader != null) 'Authorization': Session.authHeader!,
+        ...?extra,
+      };
+
+  Future<http.Response> get(
+    String path, {
+    Map<String, String>? query,
+    Map<String, String>? headers,
+    bool withAuth = true,
+  }) {
+    return _http.get(_uri(path, query), headers: _headers(withAuth: withAuth, extra: headers));
+  }
+
+  Future<http.Response> post(
+    String path, {
+    String? body,
+    Map<String, String>? query,
+    Map<String, String>? headers,
+    bool withAuth = true,
+  }) {
+    return _http.post(_uri(path, query), headers: _headers(withAuth: withAuth, extra: headers), body: body);
+  }
+
+  Future<http.Response> put(
+    String path, {
+    String? body,
+    Map<String, String>? query,
+    Map<String, String>? headers,
+    bool withAuth = true,
+  }) {
+    return _http.put(_uri(path, query), headers: _headers(withAuth: withAuth, extra: headers), body: body);
+  }
+
+  Future<http.Response> delete(
+    String path, {
+    Map<String, String>? query,
+    Map<String, String>? headers,
+    bool withAuth = true,
+  }) {
+    return _http.delete(_uri(path, query), headers: _headers(withAuth: withAuth, extra: headers));
+  }
+}
+
+
+
+
+
+
+
+
+
+

--- a/lib/core/session.dart
+++ b/lib/core/session.dart
@@ -1,0 +1,31 @@
+/// Sesión simple para cliente web.
+class Session {
+  /// ¿El usuario actual es ADMIN?
+  static bool isAdmin = false;
+
+  /// Usuario (email/login) para enviar al backend en reservas.
+  static String? username;
+
+  /// Credencial en base64 "user:pass" (sin el prefijo "Basic ").
+  static String? basicAuth;
+
+  /// Header Authorization listo para usar.
+  static String? get authHeader => (basicAuth != null) ? 'Basic $basicAuth' : null;
+
+  /// Headers por defecto (solo Authorization).
+  static Map<String, String> get defaultHeaders =>
+      authHeader != null ? {'Authorization': authHeader!} : {};
+
+  /// Limpia cualquier rastro de sesión.
+  static void clear() {
+    basicAuth = null;
+    username  = null;
+    isAdmin   = false;
+  }
+}
+
+
+
+
+
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,26 +1,37 @@
 import 'package:flutter/material.dart';
-import 'ui/home_page.dart';
+import 'ui/shell_page.dart';
+import 'ui/login_page.dart';
+import 'ui/register_page.dart';
 
-/// Punto de entrada de mi app.
 void main() {
-  runApp(const ReservaCanchasApp());
+  runApp(const App());
 }
 
-/// Configuración general de temas y ruta inicial.
-class ReservaCanchasApp extends StatelessWidget {
-  const ReservaCanchasApp({super.key});
+class App extends StatelessWidget {
+  const App({super.key});
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Reserva de Canchas',
       debugShowCheckedModeBanner: false,
+      title: 'Reserva de Canchas',
+      // IMPORTANTE: definimos /shell para que el login haga pushReplacementNamed('/shell')
+      initialRoute: '/shell',
+      routes: {
+        '/shell': (_) => const ShellPage(),
+        '/login': (_) => const LoginPage(),
+        '/register': (_) => const RegisterPage(),
+      },
+      // si alguien navega a una ruta rara, lo mando al shell
+      onUnknownRoute: (_) =>
+          MaterialPageRoute(builder: (_) => const ShellPage()),
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.green),
+        colorSchemeSeed: Colors.green,
         useMaterial3: true,
       ),
-      home: const HomePage(),
     );
   }
 }
+
+
 

--- a/lib/models/cancha.dart
+++ b/lib/models/cancha.dart
@@ -1,15 +1,26 @@
-// lib/models/cancha.dart
-// Modelo de Cancha alineado con lo que devuelve el backend.
-// OJO: el backend envía "sede" como OBJETO { id, nombre, direccion }, no "sede_id".
+class Sede {
+  final int id;
+  final String nombre;
+  final String direccion;
 
-import 'sede.dart';
+  Sede({required this.id, required this.nombre, required this.direccion});
+
+  factory Sede.fromJson(Map<String, dynamic> j) =>
+      Sede(id: j['id'], nombre: j['nombre'], direccion: j['direccion']);
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'nombre': nombre,
+        'direccion': direccion,
+      };
+}
 
 class Cancha {
   final int id;
   final String nombre;
   final String deporte;
   final bool activa;
-  final Sede sede; // <- ahora guardo el objeto Sede completo
+  final Sede sede;
 
   Cancha({
     required this.id,
@@ -19,14 +30,23 @@ class Cancha {
     required this.sede,
   });
 
-  factory Cancha.fromJson(Map<String, dynamic> json) {
-    return Cancha(
-      id: json['id'] as int,
-      nombre: json['nombre'] as String,
-      deporte: json['deporte'] as String,
-      activa: json['activa'] as bool,
-      sede: Sede.fromJson(json['sede'] as Map<String, dynamic>), // <- parseo la sede
-    );
-  }
+  factory Cancha.fromJson(Map<String, dynamic> j) => Cancha(
+        id: j['id'],
+        nombre: j['nombre'],
+        deporte: j['deporte'],
+        activa: j['activa'] == true,
+        sede: Sede.fromJson(j['sede']),
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'nombre': nombre,
+        'deporte': deporte,
+        'activa': activa,
+        'sede': sede.toJson(),
+      };
 }
+
+
+
 

--- a/lib/models/reserva.dart
+++ b/lib/models/reserva.dart
@@ -1,28 +1,43 @@
 class Reserva {
-  final int id;
-  final int canchaId;
-  final String usuario;
-  final DateTime inicio;
-  final DateTime fin;
-  final String estado;
+  final int? id;
+  final int? canchaId;
+  final String? canchaNombre;
+  final String? usuario;
+  final DateTime? inicio;
+  final DateTime? fin;
+  final String? estado;
 
-  Reserva({
-    required this.id,
-    required this.canchaId,
-    required this.usuario,
-    required this.inicio,
-    required this.fin,
-    required this.estado,
+  const Reserva({
+    this.id,
+    this.canchaId,
+    this.canchaNombre,
+    this.usuario,
+    this.inicio,
+    this.fin,
+    this.estado,
   });
 
-  factory Reserva.fromJson(Map<String, dynamic> json) {
-    return Reserva(
-      id: json['id'],
-      canchaId: json['cancha_id'],
-      usuario: json['usuario'],
-      inicio: DateTime.parse(json['inicio']),
-      fin: DateTime.parse(json['fin']),
-      estado: json['estado'],
-    );
-  }
+  factory Reserva.fromJson(Map<String, dynamic> j) => Reserva(
+        id: (j['id'] as num?)?.toInt(),
+        canchaId: (j['canchaId'] as num?)?.toInt(),
+        canchaNombre: j['canchaNombre'] as String?,
+        usuario: j['usuario'] as String?,
+        inicio: j['inicio'] != null ? DateTime.parse(j['inicio']) : null,
+        fin: j['fin'] != null ? DateTime.parse(j['fin']) : null,
+        estado: j['estado'] as String?,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'canchaId': canchaId,
+        'canchaNombre': canchaNombre,
+        'usuario': usuario,
+        'inicio': inicio?.toIso8601String(),
+        'fin': fin?.toIso8601String(),
+        'estado': estado,
+      };
 }
+
+
+
+

--- a/lib/models/sede.dart
+++ b/lib/models/sede.dart
@@ -1,20 +1,14 @@
 class Sede {
   final int id;
   final String nombre;
-  final String direccion;
 
-  Sede({
-    required this.id,
-    required this.nombre,
-    required this.direccion,
-  });
+  Sede({required this.id, required this.nombre});
 
-  factory Sede.fromJson(Map<String, dynamic> json) {
-    return Sede(
-      id: json['id'],
-      nombre: json['nombre'],
-      direccion: json['direccion'],
-    );
-  }
+  factory Sede.fromJson(Map<String, dynamic> j) =>
+      Sede(id: j['id'] as int, nombre: j['nombre'] as String? ?? 'Sede');
+
+  Map<String, dynamic> toJson() => {'id': id, 'nombre': nombre};
 }
+
+
 

--- a/lib/models/slot.dart
+++ b/lib/models/slot.dart
@@ -1,0 +1,9 @@
+class Slot {
+  final DateTime inicio;
+  final DateTime fin;
+
+  Slot({required this.inicio, required this.fin});
+
+  factory Slot.fromJson(Map<String, dynamic> j) =>
+      Slot(inicio: DateTime.parse(j['inicio']), fin: DateTime.parse(j['fin']));
+}

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -1,0 +1,16 @@
+enum UserRole { admin, user }
+
+UserRole roleFromString(String s) =>
+    s.toLowerCase() == 'admin' ? UserRole.admin : UserRole.user;
+
+class AppUser {
+  final String username;
+  final UserRole role;
+  final String token; // si tu backend devuelve JWT o similar
+
+  const AppUser({
+    required this.username,
+    required this.role,
+    required this.token,
+  });
+}

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,0 +1,50 @@
+import 'dart:convert';
+import '../core/api_client.dart';
+import '../core/session.dart';
+
+class AuthService {
+  /// Intenta loguear con Basic Auth. Devuelve true si la credencial funciona.
+  Future<bool> login({
+    required String email,
+    required String password,
+    required bool isAdmin,
+  }) async {
+    final basic = 'Basic ${base64Encode(utf8.encode('$email:$password'))}';
+
+    // seteo provisional para probar
+    Session.basicAuth = basic;
+    Session.isAdmin   = isAdmin;
+
+    // validamos pegándole a un endpoint protegido
+    final r = await ApiClient.get('/api/reservas');
+    if (r.statusCode == 200) {
+      return true;
+    }
+
+    // si falla, limpiamos sesión y devolvemos false
+    Session.clear();
+    return false;
+  }
+
+  /// Registro de usuario (ajusta el endpoint si el tuyo es distinto)
+  Future<bool> registrar({
+    required String nombre,
+    required String email,
+    required String password,
+    required String rol, // 'user' o 'admin'
+  }) async {
+    final res = await ApiClient.post('/api/usuarios', {
+      'nombre': nombre,
+      'email': email,
+      'password': password,
+      'rol': rol.toUpperCase(), // si tu backend espera ADMIN/USER
+    });
+    return res.statusCode == 200 || res.statusCode == 201;
+  }
+}
+
+
+
+
+
+

--- a/lib/services/cancha_service.dart
+++ b/lib/services/cancha_service.dart
@@ -1,26 +1,66 @@
+// lib/services/cancha_service.dart
 import 'dart:convert';
-import 'package:http/http.dart' as http;
-import '../config/env.dart';
-import '../models/cancha.dart';
 
-/// Servicio que habla con mi backend (Spring) para obtener las canchas.
+import 'package:reservacanchaf_frontend/core/api_client.dart';
+import 'package:reservacanchaf_frontend/models/cancha.dart' as cmodel;
+
 class CanchaService {
-  /// Traigo todas las canchas con un GET a `${Env.baseUrl}/api/canchas`.
-  Future<List<Cancha>> getCanchas() async {
-    final uri = Uri.parse('${Env.baseUrl}/api/canchas/activas');
+  final _api = ApiClient();
 
-    final resp = await http.get(uri, headers: {
-      'Content-Type': 'application/json',
-    });
-
-    if (resp.statusCode == 200) {
-      // Mi backend devuelve un JSON con lista de canchas
-      final List data = json.decode(resp.body);
-      return data.map((e) => Cancha.fromJson(e as Map<String, dynamic>)).toList();
+  Future<List<cmodel.Cancha>> activas() async {
+    final r = await _api.get('/api/canchas/activas');
+    if (r.statusCode != 200) {
+      throw Exception('Error listando canchas activas: ${r.statusCode}');
     }
 
-    // Si algo falla, lanzo una excepción para mostrar error en UI
-    throw Exception('Error ${resp.statusCode} al cargar canchas');
+    final data = jsonDecode(r.body) as List;
+
+    return data.map<cmodel.Cancha>((e) {
+      final m = (e as Map).cast<String, dynamic>();
+
+      // Si tu modelo tiene fromJson, úsalo primero
+      try {
+        return cmodel.Cancha.fromJson(m);
+      } catch (_) {
+        // Fallback manual si el fromJson no calza
+        final sedeMap = (m['sede'] as Map?)?.cast<String, dynamic>();
+
+        final cmodel.Sede sede = cmodel.Sede(
+          id: (sedeMap?['id'] as num?)?.toInt() ?? 0,
+          nombre: (sedeMap?['nombre'] ?? '').toString(),
+          direccion: (sedeMap?['direccion'] ?? '').toString(), // <- OBLIGATORIO
+        );
+
+        return cmodel.Cancha(
+          id: (m['id'] as num?)?.toInt() ?? 0,
+          activa: (m['activa'] as bool?) ?? true,
+          nombre: (m['nombre'] ?? '').toString(),
+          deporte: (m['deporte'] ?? '').toString(),
+          sede: sede,
+        );
+      }
+    }).toList();
+  }
+
+  Future<void> eliminar(int id) async {
+    final r = await _api.delete('/api/canchas/$id');
+    if (r.statusCode < 200 || r.statusCode >= 300) {
+      throw Exception('Error eliminando cancha: ${r.statusCode} - ${r.body}');
+    }
   }
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 

--- a/lib/services/reservas_service.dart
+++ b/lib/services/reservas_service.dart
@@ -1,0 +1,108 @@
+// lib/services/reservas_service.dart
+import 'dart:convert';
+import 'package:reservacanchaf_frontend/core/api_client.dart';
+import 'package:reservacanchaf_frontend/core/session.dart';
+import 'package:reservacanchaf_frontend/models/reserva.dart';
+
+class ReservasService {
+  final _api = ApiClient();
+
+  Future<List<Reserva>> listar() async {
+    final r = await _api.get('/api/reservas');
+    if (r.statusCode != 200) {
+      throw Exception('Error listando reservas: ${r.statusCode}');
+    }
+    final data = jsonDecode(r.body) as List;
+
+    // Usa fromJson si existe; si no, hace un mapeo manual tipado.
+    return data.map<Reserva>((e) {
+      final m = e as Map<String, dynamic>;
+      try {
+        // si tu modelo tiene fromJson, esto compila
+        return Reserva.fromJson(m);
+      } catch (_) {
+        // fallback seguro si no existe fromJson
+        return Reserva(
+          id: (m['id'] as num?)?.toInt(),
+          inicio: DateTime.tryParse(m['inicio']?.toString() ?? ''),
+          fin: DateTime.tryParse(m['fin']?.toString() ?? ''),
+          estado: m['estado']?.toString(),
+        );
+      }
+    }).toList();
+  }
+
+  Future<void> crear({
+    required int canchaId,
+    required DateTime inicio,
+    required DateTime fin,
+  }) async {
+    final body = jsonEncode({
+      'canchaId': canchaId,
+      'inicio': inicio.toIso8601String(),
+      'fin': fin.toIso8601String(),
+      'usuario': Session.username ?? 'user',
+    });
+
+    final r = await _api.post('/api/reservas', body: body);
+    if (r.statusCode < 200 || r.statusCode >= 300) {
+      throw Exception('Error creando reserva: ${r.statusCode} - ${r.body}');
+    }
+  }
+
+  Future<void> actualizar({
+    required int id,
+    required int canchaId,
+    required DateTime inicio,
+    required DateTime fin,
+  }) async {
+    final body = jsonEncode({
+      'canchaId': canchaId,
+      'inicio': inicio.toIso8601String(),
+      'fin': fin.toIso8601String(),
+      'usuario': Session.username ?? 'user',
+    });
+
+    final r = await _api.put('/api/reservas/$id', body: body);
+    if (r.statusCode < 200 || r.statusCode >= 300) {
+      throw Exception('Error actualizando reserva: ${r.statusCode} - ${r.body}');
+    }
+  }
+
+  /// Cancela robusto (prueba 3 rutas comunes).
+  Future<void> cancelar(int id) async {
+    // Plan A: POST /cancelar
+    try {
+      final r1 = await _api.post('/api/reservas/$id/cancelar', body: jsonEncode({}));
+      if (r1.statusCode >= 200 && r1.statusCode < 300) return;
+    } catch (_) {}
+
+    // Plan B: DELETE /{id}
+    try {
+      final r2 = await _api.delete('/api/reservas/$id');
+      if (r2.statusCode >= 200 && r2.statusCode < 300) return;
+    } catch (_) {}
+
+    // Plan C: PUT estado=CANCELADA
+    final r3 = await _api.put('/api/reservas/$id', body: jsonEncode({'estado': 'CANCELADA'}));
+    if (r3.statusCode < 200 || r3.statusCode >= 300) {
+      throw Exception('Error cancelando reserva: ${r3.statusCode} - ${r3.body}');
+    }
+  }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/lib/ui/cancha_detail_page.dart
+++ b/lib/ui/cancha_detail_page.dart
@@ -1,155 +1,69 @@
+import 'package:flutter/material.dart';
+import '../models/cancha.dart';
 
-// lib/ui/cancha_detail_page.dart
- // Pantalla de detalle de la cancha: hero image, info y botón "Reservar".
+class CanchaDetailPage extends StatelessWidget {
+  final Cancha cancha;
+  const CanchaDetailPage({required this.cancha, super.key});
 
- import 'package:flutter/material.dart';
- import '../models/cancha.dart';
+  String _assetForCancha() {
+    final n = cancha.nombre.toLowerCase();
+    if (n.contains('norte')) return 'assets/canchas/cancha_norte.jpg';
+    if (n.contains('techada')) return 'assets/canchas/cancha_techada.jpg';
+    return 'assets/canchas/cancha_sur.jpg';
+  }
 
- class CanchaDetailPage extends StatelessWidget {
-   const CanchaDetailPage({super.key, required this.cancha});
+  @override
+  Widget build(BuildContext context) {
+    final asset = _assetForCancha();
+    return Scaffold(
+      appBar: AppBar(title: Text(cancha.nombre)),
+      body: ListView(
+        children: [
+          AspectRatio(
+            aspectRatio: 16 / 9,
+            child: Image.asset(asset, fit: BoxFit.cover),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(cancha.nombre,
+                    style: Theme.of(context).textTheme.headlineSmall),
+                const SizedBox(height: 8),
+                Text('Deporte: ${cancha.deporte}'),
+                const SizedBox(height: 8),
+                Text('Sede: ${cancha.sede.nombre}'),
+                const SizedBox(height: 4),
+                Text('Dirección: ${cancha.sede.direccion}'),
+                const SizedBox(height: 16),
+                Row(
+                  children: [
+                    Chip(
+                      label: Text(cancha.activa ? 'ACTIVA' : 'INACTIVA'),
+                      backgroundColor:
+                          cancha.activa ? Colors.green.shade100 : Colors.red.shade100,
+                      side: BorderSide.none,
+                      labelStyle: TextStyle(
+                        color: cancha.activa ? Colors.green.shade900 : Colors.red.shade900,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
 
-   final Cancha cancha;
 
-   String _imagenDeporte() {
-     final d = cancha.deporte.toLowerCase();
-     if (d.contains('fut') || d.contains('fútbol') || d.contains('futbol')) {
-       return 'assets/canchas/cancha_norte.jpg'; // usa la que prefieras como genérica
-     }
-     // puedes añadir mapeos a otros deportes si luego los tienen
-     return 'assets/canchas/cancha_norte.jpg';
-   }
 
-   @override
-   Widget build(BuildContext context) {
-     final imgPath = _imagenDeporte();
 
-     return Scaffold(
-       appBar: AppBar(
-         title: Text(cancha.nombre),
-       ),
-       body: ListView(
-         children: [
-           // Imagen superior (hero)
-           AspectRatio(
-             aspectRatio: 16 / 6,
-             child: Image.asset(
-               imgPath,
-               fit: BoxFit.cover,
-             ),
-           ),
 
-           const SizedBox(height: 12),
-
-           // Info general
-           Card(
-             margin: const EdgeInsets.symmetric(horizontal: 16),
-             child: Padding(
-               padding: const EdgeInsets.all(16),
-               child: Column(
-                 crossAxisAlignment: CrossAxisAlignment.start,
-                 children: [
-                   _InfoRow(
-                     icon: Icons.sports_soccer,
-                     label: 'Deporte',
-                     value: cancha.deporte,
-                   ),
-                   const SizedBox(height: 8),
-                   _InfoRow(
-                     icon: Icons.verified,
-                     label: 'Estado',
-                     value: cancha.activa ? 'Activa' : 'Inactiva',
-                     valueColor: cancha.activa ? Colors.green : Colors.red,
-                   ),
-                 ],
-               ),
-             ),
-           ),
-
-           const SizedBox(height: 12),
-
-           // Info sede
-           Padding(
-             padding: const EdgeInsets.symmetric(horizontal: 16),
-             child: Text('Sede', style: Theme.of(context).textTheme.titleMedium),
-           ),
-           Card(
-             margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-             child: Padding(
-               padding: const EdgeInsets.all(16),
-               child: Column(
-                 children: [
-                   _InfoRow(
-                     icon: Icons.apartment,
-                     label: 'Nombre',
-                     value: cancha.sede.nombre,
-                   ),
-                   const SizedBox(height: 8),
-                   _InfoRow(
-                     icon: Icons.confirmation_number,
-                     label: 'Sede ID',
-                     value: '${cancha.sede.id}',
-                   ),
-                   const SizedBox(height: 8),
-                   _InfoRow(
-                     icon: Icons.location_on,
-                     label: 'Dirección',
-                     value: cancha.sede.direccion,
-                   ),
-                 ],
-               ),
-             ),
-           ),
-
-           const SizedBox(height: 100),
-         ],
-       ),
-
-       // Botón de acción (reservar)
-       floatingActionButton: FloatingActionButton.extended(
-         onPressed: () {
-           ScaffoldMessenger.of(context).showSnackBar(
-             const SnackBar(content: Text('Aquí irá el formulario de reserva ')),
-           );
-           // Aquí luego navegaremos a ReserveFormPage(...)
-         },
-         icon: const Icon(Icons.event_available),
-         label: const Text('Reservar'),
-       ),
-       floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
-     );
-   }
- }
-
- class _InfoRow extends StatelessWidget {
-   const _InfoRow({
-     required this.icon,
-     required this.label,
-     required this.value,
-     this.valueColor,
-   });
-
-   final IconData icon;
-   final String label;
-   final String value;
-   final Color? valueColor;
-
-   @override
-   Widget build(BuildContext context) {
-     final styleLabel = Theme.of(context).textTheme.bodyMedium;
-     final styleValue = Theme.of(context).textTheme.bodyMedium?.copyWith(
-           fontWeight: FontWeight.w600,
-           color: valueColor,
-         );
-     return Row(
-       children: [
-         Icon(icon, size: 18),
-         const SizedBox(width: 8),
-         Text('$label: ', style: styleLabel),
-         Expanded(child: Text(value, style: styleValue)),
-       ],
-     );
-   }
- }
 
 
 

--- a/lib/ui/canchas_list.dart
+++ b/lib/ui/canchas_list.dart
@@ -1,0 +1,153 @@
+// lib/ui/canchas_list.dart
+import 'package:flutter/material.dart';
+
+import '../core/session.dart';
+import '../models/cancha.dart' as cmodel;
+import '../services/cancha_service.dart';
+import 'cancha_detail_page.dart';
+
+class CanchasListPage extends StatefulWidget {
+  const CanchasListPage({super.key});
+
+  @override
+  State<CanchasListPage> createState() => _CanchasListPageState();
+}
+
+class _CanchasListPageState extends State<CanchasListPage> {
+  final _svc = CanchaService();
+
+  Future<void> _eliminar(cmodel.Cancha c) async {
+    try {
+      await _svc.eliminar(c.id!.toInt());
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Cancha eliminada')),
+        );
+        setState(() {}); // refrescar
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('No se pudo eliminar: $e')),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: FutureBuilder<List<cmodel.Cancha>>(
+        future: _svc.activas(),
+        builder: (_, snap) {
+          if (snap.connectionState != ConnectionState.done) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snap.hasError) {
+            return Center(
+              child: Text('Error: ${snap.error}', style: const TextStyle(color: Colors.red)),
+            );
+          }
+          final items = snap.data ?? const <cmodel.Cancha>[];
+
+          if (items.isEmpty) {
+            return const Center(child: Text('No hay canchas activas'));
+          }
+
+          return ListView.builder(
+            padding: const EdgeInsets.all(16),
+            itemCount: items.length,
+            itemBuilder: (_, i) {
+              final c = items[i];
+              return Card(
+                margin: const EdgeInsets.only(bottom: 16),
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        c.nombre ?? 'Cancha ${c.id}',
+                        style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
+                      ),
+                      const SizedBox(height: 6),
+                      Text('Deporte: ${c.deporte ?? '-'}'),
+                      const SizedBox(height: 4),
+                      Text('Sede: ${c.sede?.nombre ?? '-'}'),
+                      const SizedBox(height: 4),
+                      Text('Dirección: ${c.sede?.direccion ?? '-'}'),
+                      const SizedBox(height: 10),
+                      if (Session.isAdmin)
+                        Row(
+                          children: [
+                            OutlinedButton.icon(
+                              icon: const Icon(Icons.edit, size: 18),
+                              label: const Text('Editar'),
+                              onPressed: () {
+                                Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                    builder: (_) => CanchaDetailPage(cancha: c),
+                                  ),
+                                ).then((_) => setState(() {}));
+                              },
+                            ),
+                            const SizedBox(width: 8),
+                            OutlinedButton.icon(
+                              icon: const Icon(Icons.delete, size: 18),
+                              label: const Text('Eliminar'),
+                              onPressed: () => _eliminar(c),
+                            ),
+                          ],
+                        ),
+                    ],
+                  ),
+                ),
+              );
+            },
+          );
+        },
+      ),
+      floatingActionButton: Session.isAdmin
+          ? FloatingActionButton(
+              tooltip: 'Nueva cancha',
+              onPressed: () {
+                // Objeto "vacío" para el formulario de detalle
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => CanchaDetailPage(
+                      cancha: cmodel.Cancha(
+                        id: 0,                // 0 => nueva
+                        activa: true,
+                        nombre: '',
+                        deporte: '',
+                        sede: cmodel.Sede(
+                          id: 0,
+                          nombre: '',
+                          direccion: '', // <- obligatorio en tu modelo
+                        ),
+                      ),
+                    ),
+                  ),
+                ).then((_) => setState(() {}));
+              },
+              child: const Icon(Icons.add),
+            )
+          : null,
+    );
+  }
+}
+
+
+
+
+
+
+
+
+
+
+
+

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -1,128 +1,223 @@
-// lib/ui/home_page.dart
-// Pantalla principal donde muestro el listado de canchas.
-// Incluye: pull-to-refresh, navegación al detalle y uso de la imagen por cancha en la pantalla de detalle.
-
 import 'package:flutter/material.dart';
+import '../core/session.dart';
 import '../models/cancha.dart';
 import '../services/cancha_service.dart';
-import 'cancha_detail_page.dart';
+import 'canchas_list.dart';
+import 'reservas_page.dart';
+import 'register_page.dart';
+import 'login_page.dart';
+import '../widgets/cancha_card.dart';
 
-class HomePage extends StatefulWidget {
-  const HomePage({super.key});
 
-  @override
-  State<HomePage> createState() => _HomePageState();
-}
+class HomePage extends StatelessWidget {
+  final void Function(int index)? onJumpToTab;
+  const HomePage({super.key, this.onJumpToTab});
 
-class _HomePageState extends State<HomePage> {
-  final _service = CanchaService();
-  late Future<List<Cancha>> _future;
-
-  @override
-  void initState() {
-    super.initState();
-    _future = _service.getCanchas();
+  void _go(BuildContext ctx, int tab, Widget page) {
+    if (onJumpToTab != null) {
+      onJumpToTab!(tab);
+    } else {
+      Navigator.of(ctx).push(MaterialPageRoute(builder: (_) => page));
+    }
   }
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Canchas disponibles')),
-      body: RefreshIndicator(
-        onRefresh: () async {
-          setState(() {
-            _future = _service.getCanchas();
-          });
-          await _future;
-        },
-        child: FutureBuilder<List<Cancha>>(
-          future: _future,
-          builder: (context, snapshot) {
-            if (snapshot.connectionState == ConnectionState.waiting) {
-              return const Center(child: CircularProgressIndicator());
-            }
+    final isAdmin = Session.isAdmin;
 
-            if (snapshot.hasError) {
-              return Center(
+    return Scaffold(
+      appBar: AppBar(title: Text('Reserva de Canchas – ${isAdmin ? 'admin' : 'user'}')),
+      body: ListView(
+        children: [
+          // Banner futbolero
+          AspectRatio(
+            aspectRatio: 16 / 9,
+            child: Stack(
+              fit: StackFit.expand,
+              children: [
+                Image.asset('assets/canchas/cancha_norte.jpg', fit: BoxFit.cover),
+                Container(color: Colors.black26),
+                const Center(
+                  child: Text(
+                    'Reserva tu cancha fácil y rápido',
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      fontSize: 32,
+                      color: Colors.white,
+                      fontWeight: FontWeight.w900,
+                      height: 1.2,
+                      shadows: [Shadow(color: Colors.black54, blurRadius: 6)],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+          const SizedBox(height: 14),
+
+          // Acceso rápido
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Wrap(
+              spacing: 14, runSpacing: 14,
+              children: [
+                _HomeTile(
+                  icon: Icons.stadium, title: 'Listado de canchas',
+                  onTap: () => _go(context, 1, const CanchasListPage()),
+                ),
+                _HomeTile(
+                  icon: Icons.calendar_month, title: 'Calendario / Reservas',
+                  onTap: () => _go(context, 2, const ReservasPage()),
+                ),
+                _HomeTile(
+                  icon: Icons.person, title: 'Perfil / Crear usuario',
+                  onTap: () => _go(context, 3, const RegisterPage()),
+                ),
+              ],
+            ),
+          ),
+
+          const SizedBox(height: 8),
+
+          // Login / Registro si no hay sesión
+          if (Session.basicAuth == null)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Card(
+                elevation: 1,
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
                 child: Padding(
-                  padding: const EdgeInsets.all(24),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
+                  padding: const EdgeInsets.all(16),
+                  child: Wrap(
+                    spacing: 12, runSpacing: 12,
+                    crossAxisAlignment: WrapCrossAlignment.center,
                     children: [
-                      Text(
-                        'Ocurrió un error: ${snapshot.error}',
-                        textAlign: TextAlign.center,
+                      const Icon(Icons.lock_open, size: 28),
+                      const Text('¿Tienes cuenta?', style: TextStyle(fontWeight: FontWeight.w700)),
+                      FilledButton(
+                        onPressed: () => Navigator.of(context).push(MaterialPageRoute(builder: (_) => const LoginPage())),
+                        child: const Text('Iniciar sesión'),
                       ),
-                      const SizedBox(height: 12),
-                      OutlinedButton.icon(
-                        onPressed: () {
-                          setState(() {
-                            _future = _service.getCanchas();
-                          });
-                        },
-                        icon: const Icon(Icons.refresh),
-                        label: const Text('Reintentar'),
+                      OutlinedButton(
+                        onPressed: () => _go(context, 3, const RegisterPage()),
+                        child: const Text('Crear usuario'),
                       ),
                     ],
                   ),
                 ),
-              );
-            }
+              ),
+            ),
 
-            final canchas = snapshot.data ?? [];
-            if (canchas.isEmpty) {
-              return const Center(child: Text('No hay canchas registradas'));
-            }
-
-            return ListView.separated(
-              padding: const EdgeInsets.all(12),
-              itemCount: canchas.length,
-              separatorBuilder: (_, __) => const SizedBox(height: 8),
-              itemBuilder: (context, i) {
-                final c = canchas[i];
-
-                final disponible = c.activa;
-                final dispIcon = disponible ? Icons.check_circle : Icons.cancel;
-                final dispColor = disponible ? Colors.green : Colors.red;
-
-                return Card(
-                  elevation: 2,
-                  child: ListTile(
-                    leading: CircleAvatar(
-                      // ANTES: dispColor.withOpacity(0.15)  (DEPRECADO)
-                      // AHORA: usa withValues para evitar la advertencia del linter
-                      backgroundColor: dispColor.withValues(alpha: 0.15),
-                      child: Icon(dispIcon, color: dispColor),
-                    ),
-                    title: Text(c.nombre),
-                    subtitle: Text('Deporte: ${c.deporte} • Sede: ${c.sede.nombre}'),
-                    trailing: const Icon(Icons.chevron_right),
-                    onTap: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (_) => CanchaDetailPage(cancha: c),
-                        ),
-                      );
-                    },
+          if (Session.isAdmin)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+              child: Card(
+                color: Colors.green.shade50,
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Wrap(
+                    spacing: 12, runSpacing: 12, crossAxisAlignment: WrapCrossAlignment.center,
+                    children: const [
+                      Icon(Icons.admin_panel_settings, size: 28),
+                      Text('Acciones de administrador (cancha/sede) disponibles en menú Canchas.',
+                          style: TextStyle(fontWeight: FontWeight.w600)),
+                    ],
                   ),
+                ),
+              ),
+            ),
+
+          const SizedBox(height: 8),
+
+          // Canchas disponibles (cards)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+            child: FutureBuilder<List<Cancha>>(
+              future: CanchaService().activas(),
+              builder: (context, snap) {
+                if (snap.connectionState != ConnectionState.done) {
+                  return const Padding(
+                    padding: EdgeInsets.all(24.0),
+                    child: Center(child: CircularProgressIndicator()),
+                  );
+                }
+                if (snap.hasError) {
+                  return Padding(
+                    padding: const EdgeInsets.all(24.0),
+                    child: Text('Error cargando canchas: ${snap.error}', style: const TextStyle(color: Colors.red)),
+                  );
+                }
+                final data = snap.data ?? const <Cancha>[];
+                if (data.isEmpty) {
+                  return const Padding(
+                    padding: EdgeInsets.all(24.0),
+                    child: Text('No hay canchas activas por ahora.'),
+                  );
+                }
+                // grid responsivo
+                return LayoutBuilder(
+                  builder: (ctx, c) {
+                    final cols = c.maxWidth > 1200 ? 3 : (c.maxWidth > 800 ? 2 : 1);
+                    return GridView.builder(
+                      itemCount: data.length,
+                      shrinkWrap: true,
+                      physics: const NeverScrollableScrollPhysics(),
+                      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                        crossAxisCount: cols,
+                        crossAxisSpacing: 14,
+                        mainAxisSpacing: 14,
+                        childAspectRatio: 16 / 12,
+                      ),
+                      itemBuilder: (_, i) => CanchaCard(cancha: data[i]),
+                    );
+                  },
                 );
               },
-            );
-          },
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          setState(() {
-            _future = _service.getCanchas();
-          });
-        },
-        child: const Icon(Icons.refresh),
+            ),
+          ),
+        ],
       ),
     );
   }
 }
+
+class _HomeTile extends StatelessWidget {
+  final IconData icon; final String title; final VoidCallback onTap;
+  const _HomeTile({required this.icon, required this.title, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap, borderRadius: BorderRadius.circular(16),
+      child: Container(
+        width: 260, padding: const EdgeInsets.all(18),
+        decoration: BoxDecoration(
+          color: Colors.green.shade50,
+          borderRadius: BorderRadius.circular(16),
+          boxShadow: const [BoxShadow(blurRadius: 6, color: Colors.black12)],
+        ),
+        child: Row(mainAxisSize: MainAxisSize.min, children: [
+          Icon(icon, size: 28, color: Colors.green.shade700),
+          const SizedBox(width: 12),
+          Text(title, style: const TextStyle(fontWeight: FontWeight.w600)),
+        ]),
+      ),
+    );
+  }
+}
+
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/lib/ui/login_page.dart
+++ b/lib/ui/login_page.dart
@@ -1,0 +1,169 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+
+import '../core/api_client.dart';
+import '../core/session.dart';
+
+class LoginPage extends StatefulWidget {
+  const LoginPage({super.key});
+
+  @override
+  State<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
+  final _userCtrl = TextEditingController();
+  final _passCtrl = TextEditingController();
+
+  bool _isAdmin = false; // Solo afecta la UI (menús). El backend decide permisos reales.
+  bool _obscure = true;
+  bool _loading = false;
+
+  Future<void> _login() async {
+    final user = _userCtrl.text.trim();
+    final pass = _passCtrl.text;
+
+    if (user.isEmpty || pass.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Completa usuario y contraseña')),
+      );
+      return;
+    }
+
+    setState(() => _loading = true);
+    try {
+      final basic = base64Encode(utf8.encode('$user:$pass'));
+
+      // Probamos credenciales contra un endpoint protegido.
+      final api = ApiClient();
+      final resp = await api.get(
+        '/api/reservas',
+        withAuth: false,
+        headers: {'Authorization': 'Basic $basic'},
+      );
+
+      if (resp.statusCode == 200) {
+        //  Guardamos sesión para el resto de llamadas
+        Session.basicAuth = basic;
+        Session.isAdmin   = _isAdmin;
+        Session.username  = user; // <--- IMPORTANTE
+
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Sesión iniciada')),
+        );
+        Navigator.pop(context); // volvemos a donde estaba el usuario
+      } else {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Credenciales inválidas (HTTP ${resp.statusCode})')),
+        );
+      }
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Error de login: $e')),
+      );
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final inputBorder = OutlineInputBorder(
+      borderRadius: BorderRadius.circular(12),
+      borderSide: BorderSide(color: Colors.grey.shade400),
+    );
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Iniciar sesión')),
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 520),
+          child: Card(
+            elevation: 1.5,
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+            color: Colors.green.shade50.withOpacity(.35),
+            child: Padding(
+              padding: const EdgeInsets.all(24.0),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  TextField(
+                    controller: _userCtrl,
+                    decoration: InputDecoration(
+                      labelText: 'Usuario',
+                      prefixIcon: const Icon(Icons.person),
+                      border: inputBorder,
+                      focusedBorder: inputBorder,
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  TextField(
+                    controller: _passCtrl,
+                    obscureText: _obscure,
+                    decoration: InputDecoration(
+                      labelText: 'Contraseña',
+                      prefixIcon: const Icon(Icons.lock),
+                      suffixIcon: IconButton(
+                        icon: Icon(_obscure ? Icons.visibility : Icons.visibility_off),
+                        onPressed: () => setState(() => _obscure = !_obscure),
+                      ),
+                      border: inputBorder,
+                      focusedBorder: inputBorder,
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  Row(
+                    children: [
+                      const Text('Entrar como ADMIN'),
+                      const SizedBox(width: 8),
+                      Switch(
+                        value: _isAdmin,
+                        onChanged: (v) => setState(() => _isAdmin = v),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+                  SizedBox(
+                    width: double.infinity,
+                    child: FilledButton.icon(
+                      onPressed: _loading ? null : _login,
+                      icon: const Icon(Icons.login),
+                      label: _loading
+                          ? const Padding(
+                              padding: EdgeInsets.symmetric(vertical: 6),
+                              child: SizedBox(
+                                height: 20,
+                                width: 20,
+                                child: CircularProgressIndicator(strokeWidth: 2),
+                              ),
+                            )
+                          : const Text('Ingresar'),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  TextButton(
+                    onPressed: () => Navigator.pop(context),
+                    child: const Text('Cancelar'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+
+
+
+
+
+
+
+
+

--- a/lib/ui/register_page.dart
+++ b/lib/ui/register_page.dart
@@ -1,0 +1,123 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import '../core/api_client.dart';
+
+class RegisterPage extends StatefulWidget {
+  const RegisterPage({super.key});
+  @override
+  State<RegisterPage> createState() => _RegisterPageState();
+}
+
+class _RegisterPageState extends State<RegisterPage> {
+  final _nombre = TextEditingController();
+  final _email  = TextEditingController();
+  final _pass   = TextEditingController();
+  bool _admin = false;
+  bool _show = false;
+
+  Future<void> _guardar() async {
+    final nombre = _nombre.text.trim();
+    final email  = _email.text.trim();
+    final pass   = _pass.text;
+    if (nombre.isEmpty || email.isEmpty || pass.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Completa todos los campos')),
+      );
+      return;
+    }
+    // ajusta la ruta a tu backend si difiere:
+    final resp = await ApiClient().post(
+      '/api/usuarios',
+      body: jsonEncode({
+        'nombre': nombre,
+        'email': email,
+        'password': pass,
+        'rol': _admin ? 'ADMIN' : 'USER',
+      }),
+    );
+    if (resp.statusCode >= 200 && resp.statusCode < 300) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Usuario creado. Ahora inicia sesión.')),
+        );
+        Navigator.pop(context);
+      }
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Error ${resp.statusCode}: ${resp.body}')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Crear usuario')),
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 620),
+          child: Card(
+            color: Colors.green.shade50,
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  TextField(
+                    controller: _nombre,
+                    decoration: const InputDecoration(
+                      prefixIcon: Icon(Icons.badge_outlined),
+                      labelText: 'Nombre',
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  TextField(
+                    controller: _email,
+                    decoration: const InputDecoration(
+                      prefixIcon: Icon(Icons.alternate_email),
+                      labelText: 'Email',
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  TextField(
+                    controller: _pass,
+                    obscureText: !_show,
+                    decoration: InputDecoration(
+                      prefixIcon: const Icon(Icons.lock_outline),
+                      labelText: 'Contraseña',
+                      suffixIcon: IconButton(
+                        icon: Icon(_show ? Icons.visibility_off : Icons.visibility),
+                        onPressed: () => setState(() => _show = !_show),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  Row(
+                    children: [
+                      const Expanded(child: Text('Crear como ADMIN')),
+                      Switch(value: _admin, onChanged: (v) => setState(() => _admin = v)),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  FilledButton.icon(
+                    onPressed: _guardar,
+                    icon: const Icon(Icons.save),
+                    label: const Text('Guardar'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+
+
+
+
+
+

--- a/lib/ui/reserva_form_page.dart
+++ b/lib/ui/reserva_form_page.dart
@@ -1,141 +1,249 @@
+// lib/ui/reserva_form_page.dart
+import 'dart:convert';
 import 'package:flutter/material.dart';
+
+import '../core/api_client.dart';
+import '../core/session.dart';
 import '../models/cancha.dart';
+import '../services/cancha_service.dart';
+import '../services/reservas_service.dart';
 
 class ReservaFormPage extends StatefulWidget {
-  final Cancha cancha;
-  const ReservaFormPage({super.key, required this.cancha});
+  final Cancha? cancha;
+  final int? reservaId; // si viene -> editar
+
+  const ReservaFormPage({super.key, this.cancha, this.reservaId});
 
   @override
   State<ReservaFormPage> createState() => _ReservaFormPageState();
 }
 
 class _ReservaFormPageState extends State<ReservaFormPage> {
-  final _formKey = GlobalKey<FormState>();
-  final _nombreCtrl = TextEditingController();
-  DateTime? _fecha;
-  TimeOfDay? _horaInicio;
-  TimeOfDay? _horaFin;
+  final _api = ApiClient();
+  final _svcReservas = ReservasService();
+  final _svcCanchas = CanchaService();
+
+  int? _canchaId;
+  DateTime? _inicio;
+  DateTime? _fin;
+
+  List<Map<String, String>> _slots = [];
 
   @override
-  void dispose() {
-    _nombreCtrl.dispose();
-    super.dispose();
+  void initState() {
+    super.initState();
+    _canchaId = widget.cancha?.id?.toInt();
+    final now = DateTime.now();
+    _inicio = DateTime(now.year, now.month, now.day, now.hour);
+    _fin = _inicio!.add(const Duration(hours: 1));
   }
 
-  Future<void> _pickFecha() async {
-    final hoy = DateTime.now();
-    final picked = await showDatePicker(
+  Future<void> _pickInicio() async {
+    final d = await showDatePicker(
       context: context,
-      initialDate: hoy,
-      firstDate: hoy,
-      lastDate: hoy.add(const Duration(days: 60)),
+      initialDate: _inicio ?? DateTime.now(),
+      firstDate: DateTime.now().subtract(const Duration(days: 1)),
+      lastDate: DateTime.now().add(const Duration(days: 365)),
     );
-    if (picked != null) setState(() => _fecha = picked);
+    if (d == null) return;
+    final t = await showTimePicker(context: context, initialTime: TimeOfDay.fromDateTime(_inicio!));
+    if (t == null) return;
+    setState(() {
+      _inicio = DateTime(d.year, d.month, d.day, t.hour, t.minute);
+      if (_fin != null && !_fin!.isAfter(_inicio!)) {
+        _fin = _inicio!.add(const Duration(hours: 1));
+      }
+    });
   }
 
-  Future<void> _pickHoraInicio() async {
-    final picked = await showTimePicker(
+  Future<void> _pickFin() async {
+    final d = await showDatePicker(
       context: context,
-      initialTime: const TimeOfDay(hour: 18, minute: 0),
+      initialDate: _fin ?? DateTime.now(),
+      firstDate: DateTime.now().subtract(const Duration(days: 1)),
+      lastDate: DateTime.now().add(const Duration(days: 365)),
     );
-    if (picked != null) setState(() => _horaInicio = picked);
+    if (d == null) return;
+    final t = await showTimePicker(context: context, initialTime: TimeOfDay.fromDateTime(_fin!));
+    if (t == null) return;
+    setState(() {
+      _fin = DateTime(d.year, d.month, d.day, t.hour, t.minute);
+      if (_inicio != null && !_fin!.isAfter(_inicio!)) {
+        _inicio = _fin!.subtract(const Duration(hours: 1));
+      }
+    });
   }
 
-  Future<void> _pickHoraFin() async {
-    final picked = await showTimePicker(
-      context: context,
-      initialTime: const TimeOfDay(hour: 19, minute: 0),
-    );
-    if (picked != null) setState(() => _horaFin = picked);
-  }
-
-  void _enviar() {
-    if (!_formKey.currentState!.validate()) return;
-    if (_fecha == null || _horaInicio == null || _horaFin == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Selecciona fecha y horas')),
-      );
+  Future<void> _verDisponibilidad() async {
+    // Guardia: requiere login
+    if (Session.authHeader == null) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Debes iniciar sesión para ver disponibilidad')),
+        );
+      }
       return;
     }
+    if (_canchaId == null || _inicio == null || _fin == null) return;
 
-    if (_horaFin!.hour < _horaInicio!.hour ||
-        (_horaFin!.hour == _horaInicio!.hour &&
-            _horaFin!.minute <= _horaInicio!.minute)) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Hora fin debe ser mayor a inicio')),
-      );
-      return;
-    }
-
-    showDialog(
-      context: context,
-      builder: (_) => AlertDialog(
-        title: const Text('Confirmación'),
-        content: Text(
-          'Reserva solicitada para "${widget.cancha.nombre}"\n'
-          'Usuario: ${_nombreCtrl.text}\n'
-          'Fecha: ${_fecha!.day}/${_fecha!.month}/${_fecha!.year}\n'
-          'Horario: ${_horaInicio!.format(context)} - ${_horaFin!.format(context)}',
-        ),
-        actions: [
-          TextButton(onPressed: () => Navigator.pop(context), child: const Text('Cerrar')),
-        ],
-      ),
+    final r = await _api.get(
+      '/api/disponibilidad',
+      query: {
+        'canchaId': _canchaId!.toString(),
+        'from': _inicio!.toIso8601String(),
+        'to': _fin!.toIso8601String(),
+        'slotMin': '60',
+      },
     );
+
+    if (r.statusCode == 200) {
+      final data = jsonDecode(r.body) as List;
+      _slots = data.map<Map<String, String>>((e) {
+        final m = e as Map<String, dynamic>;
+        return {
+          'from': m['from']?.toString() ?? '',
+          'to': m['to']?.toString() ?? '',
+        };
+      }).toList();
+      if (mounted) setState(() {});
+    } else {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Error consultando disponibilidad: ${r.statusCode}')),
+        );
+      }
+    }
+  }
+
+  Future<void> _guardar() async {
+    if (_canchaId == null || _inicio == null || _fin == null) return;
+
+    try {
+      if (widget.reservaId == null) {
+        await _svcReservas.crear(
+          canchaId: _canchaId!,
+          inicio: _inicio!,
+          fin: _fin!,
+        );
+      } else {
+        await _svcReservas.actualizar(
+          id: widget.reservaId!,
+          canchaId: _canchaId!,
+          inicio: _inicio!,
+          fin: _fin!,
+        );
+      }
+
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Reserva guardada')),
+      );
+      Navigator.pop(context);
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('No se pudo guardar la reserva: $e')),
+      );
+    }
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Reservar cancha')),
-      body: Form(
-        key: _formKey,
-        child: ListView(
-          padding: const EdgeInsets.all(16),
-          children: [
-            Text('Cancha: ${widget.cancha.nombre}',
-                style: const TextStyle(fontWeight: FontWeight.bold)),
-            const SizedBox(height: 12),
-            TextFormField(
-              controller: _nombreCtrl,
-              decoration: const InputDecoration(
-                labelText: 'Tu nombre',
-                border: OutlineInputBorder(),
+      appBar: AppBar(title: Text(widget.reservaId == null ? 'Nueva reserva' : 'Editar reserva')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          // Selección de cancha
+          FutureBuilder<List<Cancha>>(
+            future: _svcCanchas.activas(),
+            builder: (_, snap) {
+              final items = snap.data ?? const <Cancha>[];
+              return DropdownButtonFormField<int>(
+                value: _canchaId,
+                decoration: const InputDecoration(labelText: 'Cancha'),
+                items: items
+                    .map(
+                      (c) => DropdownMenuItem<int>(
+                        value: c.id?.toInt(),
+                        child: Text(c.nombre ?? 'Cancha ${c.id}'),
+                      ),
+                    )
+                    .toList(),
+                onChanged: (v) => setState(() => _canchaId = v),
+              );
+            },
+          ),
+          const SizedBox(height: 16),
+
+          // Inicio / Fin
+          Row(
+            children: [
+              Expanded(
+                child: ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  title: const Text('Inicio'),
+                  subtitle: Text(_inicio?.toIso8601String() ?? ''),
+                  trailing: const Icon(Icons.access_time),
+                  onTap: _pickInicio,
+                ),
               ),
-              validator: (v) =>
-                  v == null || v.trim().isEmpty ? 'Ingresa tu nombre' : null,
+              const SizedBox(width: 12),
+              Expanded(
+                child: ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  title: const Text('Fin'),
+                  subtitle: Text(_fin?.toIso8601String() ?? ''),
+                  trailing: const Icon(Icons.access_time),
+                  onTap: _pickFin,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+
+          // Acciones
+          Row(
+            children: [
+              FilledButton.icon(
+                onPressed: _verDisponibilidad,
+                icon: const Icon(Icons.search),
+                label: const Text('Ver disponibilidad'),
+              ),
+              const SizedBox(width: 12),
+              FilledButton.icon(
+                onPressed: _guardar,
+                icon: const Icon(Icons.save),
+                label: const Text('Guardar'),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+
+          // Slots
+          const Text('Slots disponibles:'),
+          const SizedBox(height: 8),
+          ..._slots.map(
+            (s) => Padding(
+              padding: const EdgeInsets.only(bottom: 8.0),
+              child: Chip(label: Text('${s['from']} → ${s['to']}')),
             ),
-            const SizedBox(height: 12),
-            ListTile(
-              leading: const Icon(Icons.calendar_today),
-              title: Text(_fecha == null
-                  ? 'Seleccionar fecha'
-                  : '${_fecha!.day}/${_fecha!.month}/${_fecha!.year}'),
-              onTap: _pickFecha,
-            ),
-            ListTile(
-              leading: const Icon(Icons.access_time),
-              title: Text(_horaInicio == null
-                  ? 'Hora inicio'
-                  : _horaInicio!.format(context)),
-              onTap: _pickHoraInicio,
-            ),
-            ListTile(
-              leading: const Icon(Icons.access_time_filled),
-              title:
-                  Text(_horaFin == null ? 'Hora fin' : _horaFin!.format(context)),
-              onTap: _pickHoraFin,
-            ),
-            const SizedBox(height: 16),
-            FilledButton.icon(
-              onPressed: _enviar,
-              icon: const Icon(Icons.send),
-              label: const Text('Solicitar reserva'),
-            ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }
 }
+
+
+
+
+
+
+
+
+
+
+
+
 

--- a/lib/ui/reservas_page.dart
+++ b/lib/ui/reservas_page.dart
@@ -1,0 +1,129 @@
+// lib/ui/reservas_page.dart
+import 'package:flutter/material.dart';
+import '../core/session.dart';
+import '../models/reserva.dart';
+import '../services/reservas_service.dart';
+import 'reserva_form_page.dart';
+
+class ReservasPage extends StatefulWidget {
+  const ReservasPage({super.key});
+
+  @override
+  State<ReservasPage> createState() => _ReservasPageState();
+}
+
+class _ReservasPageState extends State<ReservasPage> {
+  final _svc = ReservasService();
+
+  @override
+  Widget build(BuildContext context) {
+    // Guarda: si no hay login, no peguemos al backend
+    if (Session.authHeader == null) {
+      return const Center(
+        child: Text('Inicia sesión para ver y gestionar tus reservas'),
+      );
+    }
+
+    return Scaffold(
+      body: FutureBuilder<List<Reserva>>(
+        future: _svc.listar(),
+        builder: (context, snap) {
+          if (snap.connectionState != ConnectionState.done) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snap.hasError) {
+            return Center(
+              child: Text(
+                'Error: ${snap.error}',
+                style: const TextStyle(color: Colors.red),
+              ),
+            );
+          }
+          final items = snap.data ?? const [];
+          if (items.isEmpty) {
+            return const Center(child: Text('No tienes reservas'));
+          }
+
+          return ListView.separated(
+            padding: const EdgeInsets.all(16),
+            separatorBuilder: (_, __) => const SizedBox(height: 12),
+            itemCount: items.length,
+            itemBuilder: (_, i) {
+              final r = items[i];
+              return ListTile(
+                tileColor: Colors.green.shade50.withOpacity(.35),
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+                title: Text('Reserva #${r.id ?? '-'}'),
+                subtitle: Text('${r.inicio} → ${r.fin} · ${r.estado ?? ''}'),
+                trailing: Wrap(
+                  spacing: 4,
+                  children: [
+                    IconButton(
+                      tooltip: 'Editar',
+                      icon: const Icon(Icons.edit),
+                      onPressed: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => ReservaFormPage(reservaId: r.id),
+                          ),
+                        ).then((_) => setState(() {}));
+                      },
+                    ),
+                    IconButton(
+                      tooltip: 'Cancelar',
+                      icon: const Icon(Icons.close),
+                      onPressed: () async {
+                        try {
+                          await _svc.cancelar(r.id!.toInt());
+                          if (mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(content: Text('Reserva cancelada')),
+                            );
+                            setState(() {});
+                          }
+                        } catch (e) {
+                          if (mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(content: Text('No se pudo cancelar: $e')),
+                            );
+                          }
+                        }
+                      },
+                    ),
+                  ],
+                ),
+              );
+            },
+          );
+        },
+      ),
+
+      // FAB para crear NUEVA reserva
+      floatingActionButton: FloatingActionButton(
+        tooltip: 'Nueva reserva',
+        onPressed: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => const ReservaFormPage()),
+          ).then((_) => setState(() {}));
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/lib/ui/shell_page.dart
+++ b/lib/ui/shell_page.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import '../core/session.dart';
+import 'home_page.dart';
+import 'canchas_list.dart';
+import 'reservas_page.dart';
+import 'register_page.dart';
+
+class ShellPage extends StatefulWidget {
+  const ShellPage({super.key});
+  @override
+  State<ShellPage> createState() => _ShellPageState();
+}
+
+class _ShellPageState extends State<ShellPage> {
+  int _index = 0;
+  void _jumpTo(int i) => setState(() => _index = i);
+
+  List<Widget> get _pages => [
+        HomePage(onJumpToTab: _jumpTo),
+        const CanchasListPage(),
+        const ReservasPage(),
+        const RegisterPage(),
+      ];
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (ctx, c) {
+        final wide = c.maxWidth >= 980; // sidebar estilo desktop
+        if (wide) {
+          return Scaffold(
+            body: Row(
+              children: [
+                NavigationRail(
+                  selectedIndex: _index,
+                  onDestinationSelected: (i) => setState(() => _index = i),
+                  labelType: NavigationRailLabelType.all,
+                  leading: Padding(
+                    padding: const EdgeInsets.only(top: 12.0),
+                    child: Icon(Icons.sports_soccer, size: 32, color: Colors.green.shade700),
+                  ),
+                  trailing: Session.basicAuth != null
+                      ? Padding(
+                          padding: const EdgeInsets.only(bottom: 12.0),
+                          child: IconButton(
+                            tooltip: 'Cerrar sesión',
+                            onPressed: () {
+                              Session.clear();
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                const SnackBar(content: Text('Sesión cerrada')),
+                              );
+                              setState(() {});
+                            },
+                            icon: const Icon(Icons.logout),
+                          ),
+                        )
+                      : null,
+                  destinations: const [
+                    NavigationRailDestination(
+                      icon: Icon(Icons.home_outlined), selectedIcon: Icon(Icons.home), label: Text('Home')),
+                    NavigationRailDestination(
+                      icon: Icon(Icons.stadium_outlined), selectedIcon: Icon(Icons.stadium), label: Text('Canchas')),
+                    NavigationRailDestination(
+                      icon: Icon(Icons.calendar_month_outlined), selectedIcon: Icon(Icons.calendar_month), label: Text('Reservas')),
+                    NavigationRailDestination(
+                      icon: Icon(Icons.person_outline), selectedIcon: Icon(Icons.person), label: Text('Perfil')),
+                  ],
+                ),
+                const VerticalDivider(width: 1),
+                Expanded(child: _pages[_index]),
+              ],
+            ),
+          );
+        }
+        // móvil
+        return Scaffold(
+          body: IndexedStack(index: _index, children: _pages),
+          bottomNavigationBar: NavigationBar(
+            selectedIndex: _index,
+            onDestinationSelected: (i) => setState(() => _index = i),
+            destinations: const [
+              NavigationDestination(icon: Icon(Icons.home_outlined), selectedIcon: Icon(Icons.home), label: 'Inicio'),
+              NavigationDestination(icon: Icon(Icons.stadium), label: 'Canchas'),
+              NavigationDestination(icon: Icon(Icons.calendar_month), label: 'Reservas'),
+              NavigationDestination(icon: Icon(Icons.person_outline), selectedIcon: Icon(Icons.person), label: 'Perfil'),
+            ],
+          ),
+          floatingActionButton: Session.basicAuth != null
+              ? FloatingActionButton.extended(
+                  onPressed: () {
+                    Session.clear();
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Sesión cerrada')),
+                    );
+                    setState(() {});
+                  },
+                  icon: const Icon(Icons.logout),
+                  label: const Text('Salir'),
+                )
+              : null,
+        );
+      },
+    );
+  }
+}

--- a/lib/widgets/cancha_card.dart
+++ b/lib/widgets/cancha_card.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import '../../models/cancha.dart';
+import '../../core/session.dart';
+
+String assetForCancha(String nombre) {
+  final n = nombre.toLowerCase();
+  if (n.contains('tech')) return 'assets/canchas/cancha_techada.jpg';
+  if (n.contains('sur'))  return 'assets/canchas/cancha_sur.jpg';
+  return 'assets/canchas/cancha_norte.jpg';
+}
+
+class CanchaCard extends StatelessWidget {
+  final Cancha cancha;
+  final VoidCallback? onEliminar;
+  final VoidCallback? onEditar;
+  const CanchaCard({super.key, required this.cancha, this.onEliminar, this.onEditar});
+
+  @override
+  Widget build(BuildContext context) {
+    final dir = cancha.sede?.direccion ?? cancha.sede?.nombre ?? '-';
+    final isAdmin = Session.isAdmin;
+
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      elevation: 3,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+      child: InkWell(
+        onTap: onEditar,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Foto grande
+            SizedBox(
+              height: 200,
+              width: double.infinity,
+              child: Image.asset(
+                assetForCancha(cancha.nombre),
+                fit: BoxFit.cover,
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 14, 16, 16),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Icon(Icons.sports_soccer, color: Colors.black54),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(cancha.nombre,
+                            style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w700)),
+                        const SizedBox(height: 2),
+                        Text('Deporte: ${cancha.deporte} · Sede: $dir',
+                            style: const TextStyle(color: Colors.black54)),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                    decoration: BoxDecoration(
+                      color: (cancha.activa == true) ? Colors.green.shade100 : Colors.red.shade100,
+                      borderRadius: BorderRadius.circular(20),
+                    ),
+                    child: Text(cancha.activa == true ? 'ACTIVA' : 'INACTIVA'),
+                  ),
+                ],
+              ),
+            ),
+            if (isAdmin) Padding(
+              padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+              child: Row(
+                children: [
+                  OutlinedButton.icon(
+                    onPressed: onEditar,
+                    icon: const Icon(Icons.edit),
+                    label: const Text('Editar'),
+                  ),
+                  const SizedBox(width: 8),
+                  OutlinedButton.icon(
+                    onPressed: onEliminar,
+                    icon: const Icon(Icons.delete_outline),
+                    label: const Text('Eliminar'),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  crypto:
+    dependency: transitive
+    description:
+      name: crypto
+      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.6"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -57,6 +65,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -75,6 +99,19 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  google_fonts:
+    dependency: "direct main"
+    description:
+      name: google_fonts
+      sha256: ebc94ed30fd13cefd397cb1658b593f21571f014b7d1197eeb41fb95f05d899a
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.1"
   http:
     dependency: "direct main"
     description:
@@ -91,6 +128,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -147,6 +192,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   path:
     dependency: transitive
     description:
@@ -155,6 +208,134 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.5"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: "993381400e94d18469750e5b9dcb8206f15bc09f9da86b9e44a9b0092a0066db"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.18"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "16eef174aacb07e09c351502740fa6254c165757638eba1e9116b0a781201bbd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
+  provider:
+    dependency: "direct main"
+    description:
+      name: provider
+      sha256: "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.5+1"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: bd14436108211b0d4ee5038689a56d4ae3620fd72fd6036e113bf1345bc74d9e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.13"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -240,6 +421,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
 sdks:
   dart: ">=3.9.2 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.29.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,58 +1,30 @@
-# Nombre único del proyecto (coincide con la carpeta).
 name: reservacanchaf_frontend
-
-# Breve descripción del proyecto.
 description: "Frontend Flutter para reservar canchas (web)."
-
-# Evito publicar accidentalmente el paquete en pub.dev.
 publish_to: 'none'
-
-# Versión de la app: mayor.menor.parche + número de build.
 version: 1.0.0+1
 
-# Versión de Dart/Flutter que usa este proyecto.
 environment:
   sdk: ^3.9.2
 
-# ----------- Dependencias de la aplicación -----------
 dependencies:
-  # SDK principal de Flutter (imprescindible).
   flutter:
     sdk: flutter
-
-  # Paquete HTTP para hacer solicitudes REST a mi backend (GET/POST/PUT/DELETE).
-  http: ^1.5.0
-
-  # Íconos estilo iOS (opcional, útil si los necesito).
+  http: ^1.2.0
   cupertino_icons: ^1.0.8
+  provider: ^6.0.5
+  google_fonts: ^6.3.1
+  intl: ^0.19.0
+  shared_preferences: ^2.3.2
 
-# ----------- Dependencias solo para desarrollo/testing -----------
 dev_dependencies:
-  # Framework de pruebas unitarias/widget para Flutter.
   flutter_test:
     sdk: flutter
-
-  # Conjunto de reglas de lint recomendadas por Google para mantener buen estilo.
   flutter_lints: ^5.0.0
 
-# ----------- Configuración específica de Flutter -----------
 flutter:
-  # Incluye la tipografía de Material Icons para poder usar Icon(Icons.xxx).
   uses-material-design: true
-#-----------imagenes----------------------
   assets:
-      - assets/canchas/
+    - assets/canchas/cancha_norte.jpg
+    - assets/canchas/cancha_techada.jpg
+    - assets/canchas/cancha_sur.jpg
 
-
-  # Si más adelante cargo imágenes o JSON locales, descomento y agrego rutas aquí:
-  # assets:
-  #   - assets/images/
-  #   - assets/data/
-
-  # Para fuentes personalizadas, este sería el bloque de ejemplo:
-  # fonts:
-  #   - family: Montserrat
-  #     fonts:
-  #       - asset: assets/fonts/Montserrat-Regular.ttf
-  #       - asset: assets/fonts/Montserrat-Bold.ttf
-  #         weight: 700


### PR DESCRIPTION
 Por qué
Estabilizar flujo usuario/admin y evitar 401/400.

 Cambios
- CanchaService: parseo Sede y campos requeridos.
- ReservasService: cancelar/crear/actualizar + headers auth.
- UI: guards de sesión, botones (reservar/editar/cancelar), detalle cancha.

Cómo probar
1) flutter clean && flutter pub get
2) flutter run -d chrome --web-port 61181
3) Login con admin/Admin#2025 y user/User#2025
4) Probar reservas y CRUD de canchas.

Checklist
- [ ] Compila y corre sin logs rojos
- [ ] Botones visibles y activos según rol
- [ ] Manejo de errores de red correcto

